### PR TITLE
eos-upgrade-eos2-to-eos3: Do upgrade pull without deltas

### DIFF
--- a/eos-upgrade-eos2-to-eos3
+++ b/eos-upgrade-eos2-to-eos3
@@ -315,6 +315,11 @@ refspec=eos:os/eos/$prod/eos3
 EOF
 
 if ! $SKIP; then
+    # Pull eos3 ostree without static deltas in case this system is
+    # already suffering missing ostree objects.
+    ostree pull --repo=/ostree/repo --disable-static-deltas eos \
+           os/eos/$prod/eos3
+
     # Perform the ostree upgrade
     # Note that if there has not been an eos3 release since
     # the latest eos2 release, this chronologically will appear


### PR DESCRIPTION
In case the system is already suffering from the issue where they have
missing ostree objects, always do a pull with static deltas disabled.

We don't actually have any eos2 to eos3 deltas, so the way this would
affect you is unusual. If you have a failed upgrade to eos3, we made
another release that did have a delta from the partial eos3 you had, and
then you tried to upgrade again, you might hit this. Just do the pull
without static deltas all the time to be safe.

https://phabricator.endlessm.com/T18941